### PR TITLE
rose config-edit: washup

### DIFF
--- a/metomi/rose/config_editor/data.py
+++ b/metomi/rose/config_editor/data.py
@@ -212,7 +212,7 @@ class ConfigDataManager(object):
             "ignored": {},
         }  # Caches ns statuses
         self._config_section_namespace_map = {}  # Store section namespaces
-        self.locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
+        self.locator = metomi.rose.resource.ResourceLocator()
         if opt_meta_paths is None:
             self.opt_meta_paths = []
         else:

--- a/metomi/rose/config_editor/main.py
+++ b/metomi/rose/config_editor/main.py
@@ -2090,12 +2090,12 @@ def spawn_window(
         opt_meta_paths = []
     if not debug_mode:
         warnings.filterwarnings("ignore")
-    resourcer = metomi.rose.resource.ResourceLocator(paths=sys.path)
+    resourcer = metomi.rose.resource.ResourceLocator()
     metomi.rose.gtk.util.rc_setup(
-        str(resourcer.locate("etc/rose-config-edit/.gtkrc-2.0"))
+        str(resourcer.locate("rose-config-edit/.gtkrc-2.0"))
     )
     metomi.rose.gtk.util.setup_stock_icons()
-    logo = resourcer.locate("etc/images/rose-splash-logo.png")
+    logo = resourcer.locate("images/rose-splash-logo.png")
     if metomi.rose.config_editor.ICON_PATH_SCHEDULER is None:
         gcontrol_icon = None
     else:
@@ -2258,8 +2258,8 @@ def main():
     style_context.add_provider_for_screen(
         screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
     )
-    locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
-    css_path = locator.locate("etc/rose-config-edit/style.css")
+    locator = metomi.rose.resource.ResourceLocator()
+    css_path = locator.locate("rose-config-edit/style.css")
     provider.load_from_path(str(css_path))
 
     if opts.profile_mode:

--- a/metomi/rose/config_editor/nav_panel.py
+++ b/metomi/rose/config_editor/nav_panel.py
@@ -19,7 +19,6 @@
 # -----------------------------------------------------------------------------
 
 import re
-import sys
 
 import gi
 
@@ -116,8 +115,8 @@ class PageNavigationPanel(Gtk.ScrolledWindow):
             str,
             str,
         )
-        resource_loc = metomi.rose.resource.ResourceLocator(paths=sys.path)
-        image_path = str(resource_loc.locate("etc/images/rose-config-edit"))
+        resource_loc = metomi.rose.resource.ResourceLocator()
+        image_path = str(resource_loc.locate("images/rose-config-edit"))
         self.null_icon = GdkPixbuf.Pixbuf.new_from_file(
             image_path + "/null_icon.png"
         )

--- a/metomi/rose/config_editor/ops/__init__.py
+++ b/metomi/rose/config_editor/ops/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------

--- a/metomi/rose/config_editor/pagewidget/__init__.py
+++ b/metomi/rose/config_editor/pagewidget/__init__.py
@@ -18,5 +18,6 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-# flake8: noqa: F401
 from . import table
+
+__all__ = ["table"]

--- a/metomi/rose/config_editor/panelwidget/__init__.py
+++ b/metomi/rose/config_editor/panelwidget/__init__.py
@@ -18,6 +18,7 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-# flake8: noqa: F401
 from . import filesystem
 from . import summary_data
+
+__all__ = ['filesystem', 'summary_data']

--- a/metomi/rose/config_editor/status.py
+++ b/metomi/rose/config_editor/status.py
@@ -19,7 +19,6 @@
 # -----------------------------------------------------------------------------
 
 import datetime
-import sys
 import time
 
 import gi
@@ -130,9 +129,8 @@ class StatusBar(Gtk.Box):
                 kind = message.kind
             if level is None:
                 level = message.level
-        if level is not None:
-            if level > self.verbosity:
-                return
+        if level is not None and level > self.verbosity:
+            return
         if isinstance(message, Exception):
             kind = metomi.rose.reporter.Reporter.KIND_ERR
             level = metomi.rose.reporter.Reporter.FAIL
@@ -159,10 +157,8 @@ class StatusBar(Gtk.Box):
         # Generate the error display widget.
         self._error_widget = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self._error_widget.show()
-        locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
-        icon_path = locator.locate(
-            "etc/images/rose-config-edit/error_icon.png"
-        )
+        locator = metomi.rose.resource.ResourceLocator()
+        icon_path = locator.locate("images/rose-config-edit/error_icon.png")
         image = Gtk.Image.new_from_file(str(icon_path))
         image.show()
         self._error_widget.pack_start(

--- a/metomi/rose/config_editor/valuewidget/array/__init__.py
+++ b/metomi/rose/config_editor/valuewidget/array/__init__.py
@@ -18,9 +18,9 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 
-# flake8: noqa: F401
-
 from . import python_list
 from . import logical
 from . import mixed
 from . import spaced_list
+
+__all__ = ['python_list', 'logical', 'mixed', 'spaced_list']

--- a/metomi/rose/config_editor/valuewidget/array/entry.py
+++ b/metomi/rose/config_editor/valuewidget/array/entry.py
@@ -106,11 +106,10 @@ class EntryArrayValueWidget(Gtk.Box):
             lambda w, e: self.hook.get_focus(self.get_focus_entry()),
         )
 
-    def force_scroll(self, widget=None):
+    def force_scroll(self, widget):
         """Adjusts a scrolled window to display the correct widget."""
         y_coordinate = None
-        if widget is not None:
-            y_coordinate = widget.get_allocation().y
+        y_coordinate = widget.get_allocation().y
         scroll_container = widget.get_parent()
         if scroll_container is None:
             return False

--- a/metomi/rose/config_editor/valuewidget/array/python_list.py
+++ b/metomi/rose/config_editor/valuewidget/array/python_list.py
@@ -82,11 +82,10 @@ class PythonListValueWidget(Gtk.Box):
             lambda w, e: self.hook.get_focus(self.get_focus_entry()),
         )
 
-    def force_scroll(self, widget=None):
+    def force_scroll(self, widget):
         """Adjusts a scrolled window to display the correct widget."""
         y_coordinate = None
-        if widget is not None:
-            y_coordinate = widget.get_allocation().y
+        y_coordinate = widget.get_allocation().y
         scroll_container = widget.get_parent()
         if scroll_container is None:
             return False

--- a/metomi/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/metomi/rose/config_editor/valuewidget/array/spaced_list.py
@@ -82,11 +82,10 @@ class SpacedListValueWidget(Gtk.Box):
             lambda w, e: self.hook.get_focus(self.get_focus_entry()),
         )
 
-    def force_scroll(self, widget=None):
+    def force_scroll(self, widget):
         """Adjusts a scrolled window to display the correct widget."""
         y_coordinate = None
-        if widget is not None:
-            y_coordinate = widget.get_allocation().y
+        y_coordinate = widget.get_allocation().y
         scroll_container = widget.get_parent()
         if scroll_container is None:
             return False

--- a/metomi/rose/config_editor/variable.py
+++ b/metomi/rose/config_editor/variable.py
@@ -330,7 +330,7 @@ class VariableWidget(object):
 
         return container
 
-    def force_scroll(self, widget=None, container=None):
+    def force_scroll(self, widget, container):
         """Adjusts a scrolled window to display the correct widget."""
         y_coordinate = None
         if widget is not None:

--- a/metomi/rose/config_editor/window.py
+++ b/metomi/rose/config_editor/window.py
@@ -28,9 +28,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 import metomi.rose.config
+import metomi.rose.config_editor
 import metomi.rose.gtk.dialog
 import metomi.rose.gtk.util
-import metomi.rose.resource
 
 from functools import cmp_to_key
 
@@ -177,7 +177,7 @@ class MainWindow(object):
         metomi.rose.gtk.dialog.run_about_dialog(
             name=metomi.rose.config_editor.PROGRAM_NAME,
             copyright_=metomi.rose.config_editor.COPYRIGHT,
-            logo_path="etc/images/rose-logo.png",
+            logo_path="images/rose-logo.png",
             website=metomi.rose.config_editor.PROJECT_URL,
             website_label=metomi.rose.config_editor.PROJECT_URL,
         )

--- a/metomi/rose/gtk/dialog.py
+++ b/metomi/rose/gtk/dialog.py
@@ -303,7 +303,7 @@ def run_about_dialog(
     about_dialog.set_transient_for(parent_window)
     about_dialog.set_program_name(name)
     about_dialog.set_copyright(copyright_)
-    resource_loc = metomi.rose.resource.ResourceLocator(paths=sys.path)
+    resource_loc = metomi.rose.resource.ResourceLocator()
     logo_path = resource_loc.locate(logo_path)
     about_dialog.set_logo(GdkPixbuf.Pixbuf.new_from_file(str(logo_path)))
     about_dialog.set_website(website)

--- a/metomi/rose/gtk/util.py
+++ b/metomi/rose/gtk/util.py
@@ -21,7 +21,6 @@
 import multiprocessing
 import queue
 import re
-import sys
 import threading
 import webbrowser
 
@@ -666,13 +665,13 @@ def get_hyperlink_label(text, search_func=lambda i: False):
 
 def get_icon(system="rose"):
     """Return a GdkPixbuf.Pixbuf for the system icon."""
-    locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
-    icon_path = locator.locate("etc/images/{0}-icon-trim.svg".format(system))
+    locator = metomi.rose.resource.ResourceLocator()
+    icon_path = locator.locate("images/{0}-icon-trim.svg".format(system))
     try:
         pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(icon_path))
     except Exception:
         icon_path = locator.locate(
-            "etc/images/{0}-icon-trim.png".format(system)
+            "images/{0}-icon-trim.png".format(system)
         )
         pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(icon_path))
     return pixbuf
@@ -715,7 +714,7 @@ def rc_setup(rc_resource):
 def setup_scheduler_icon(ipath=None):
     """Setup a 'stock' icon for the scheduler"""
     theme = Gtk.IconTheme.get_default()
-    locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
+    locator = metomi.rose.resource.ResourceLocator()
     if ipath is None:
         theme.load_icon("image-missing", 64, 0)
     else:
@@ -727,7 +726,7 @@ def setup_scheduler_icon(ipath=None):
 def setup_stock_icons():
     """Setup any additional 'stock' icons."""
     new_icon_factory = Gtk.IconFactory()
-    locator = metomi.rose.resource.ResourceLocator(paths=sys.path)
+    locator = metomi.rose.resource.ResourceLocator()
     for png_icon_name in [
         "gnome_add",
         "gnome_add_errors",
@@ -738,7 +737,7 @@ def setup_stock_icons():
     ]:
         ifile = png_icon_name + ".png"
         istring = png_icon_name.replace("_", "-")
-        path = locator.locate("etc/images/rose-config-edit/" + ifile)
+        path = locator.locate("images/rose-config-edit/" + ifile)
         pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(path))
         new_icon_factory.add("rose-gtk-" + istring, Gtk.IconSet(pixbuf))
     exp_icon_pixbuf = get_icon()

--- a/metomi/rose/resource.py
+++ b/metomi/rose/resource.py
@@ -18,7 +18,7 @@
 Convenient functions for searching resource files.
 """
 
-import importlib
+from importlib.machinery import SourceFileLoader
 import inspect
 import os
 from pathlib import Path
@@ -32,7 +32,7 @@ from metomi.rose.reporter import Reporter
 
 ERROR_LOCATE_OBJECT = "Could not locate {0}"
 
-MODULES = {}
+MODULES: dict = {}
 
 
 class ResourceError(Exception):
@@ -209,20 +209,7 @@ def import_object(
         for filename in module_files:
             sys.path.insert(0, os.path.dirname(filename))
             try:
-                spec = (
-                    importlib.util.spec_from_file_location(filename, filename)
-                )
-                if filename not in MODULES:
-                    spec = (
-                        importlib.util
-                        .spec_from_file_location(filename, filename)
-                    )
-                    module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(module)
-                    MODULES[filename] = module
-                else:
-                    module = MODULES[filename]
-                sys.path.pop(0)
+                module = SourceFileLoader(module_name, filename).load_module()
             except ImportError as exc:
                 error_handler(exc)
             sys.path.pop(0)

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -97,8 +97,8 @@ Configuring Rose
 
 Rose configuration files can be located in the following places:
 
-* ``/etc/.metomi/rose.conf``
-* ``$ROSE_SITE_CONF_PATH/.metomi/rose.conf``
+* ``/etc/rose.conf``
+* ``$ROSE_SITE_CONF_PATH/rose.conf``
 * ``$HOME/.metomi/rose.conf``
 
 See :rose:file:`rose.conf` in the API reference for more information.

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -97,8 +97,8 @@ Configuring Rose
 
 Rose configuration files can be located in the following places:
 
-* ``/etc/rose.conf``
-* ``$ROSE_SITE_CONF_PATH/rose.conf``
+* ``/etc/.metomi/rose.conf``
+* ``$ROSE_SITE_CONF_PATH/.metomi/rose.conf``
 * ``$HOME/.metomi/rose.conf``
 
 See :rose:file:`rose.conf` in the API reference for more information.


### PR DESCRIPTION
* Fix lint & mypy errors.
* Revert changes in `resource.py` (these weren't necessary, the paths used in `rose edit` just needed to be fiddled).
* Address F401 lint errors by defining `__all__` at the module level.
* Add missing copyright header.
* Address an issue with the `force_scroll` methods unrelated to this change where `widget` is permitted to be `None` even though it would cause Traceback if it were.
* Fix config path in the docs.